### PR TITLE
Fix issue #16, and make arrow compile on linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@
 cmake_minimum_required (VERSION 2.6)
 project (arrow)
 
+find_package (Threads)
+
 # put all source code in one place for convenience
 file(GLOB lexer src/lexer/*.cpp src/lexer/*.hpp)
 file(GLOB parser src/parser/*.cpp src/parser/*.hpp)
@@ -39,7 +41,8 @@ target_link_libraries(arrow
                       representation_lib
                       utility_lib
                       receivers_lib
-                      builtin_lib)
+                      builtin_lib
+                      ${CMAKE_THREAD_LIBS_INIT})
 
 # compile options. Lots of redundancy here. Can prob clean up.
 set(COMP_FLAGS -std=c++17 -O3 -ffast-math -funroll-loops -Wno-ctor-dtor-privacy -fno-pic -fPIE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(arrow
                       builtin_lib)
 
 # compile options. Lots of redundancy here. Can prob clean up.
-set(COMP_FLAGS -std=c++17 -O3 -ffast-math -funroll-loops -Wno-ctor-dtor-privacy -fno-pic)
+set(COMP_FLAGS -std=c++17 -O3 -ffast-math -funroll-loops -Wno-ctor-dtor-privacy -fno-pic -fPIE)
 target_compile_options(parser_lib PUBLIC ${COMP_FLAGS})
 target_compile_options(lexer_lib PUBLIC ${COMP_FLAGS})
 target_compile_options(expressions_lib PUBLIC ${COMP_FLAGS})

--- a/examples/wildcard_match.ar
+++ b/examples/wildcard_match.ar
@@ -58,7 +58,7 @@ fn wildcard_match(needle, haystack) -> result {
             false -> result;
             return;
         } else {
-            haystack[0] -> head;
+            haystack:0 -> head;
             tail(haystack) -> newHaystack;
             if(head /= i) {
                 false -> result;

--- a/src/builtin/filesystem/evaluator/FileReadBytesFunctionExpressionEvaluator.cpp
+++ b/src/builtin/filesystem/evaluator/FileReadBytesFunctionExpressionEvaluator.cpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <fstream>
+#include <iterator>
 #include <stdexcept>
 #include <string>
 

--- a/src/expressions/Expression.hpp
+++ b/src/expressions/Expression.hpp
@@ -4,6 +4,7 @@
 
 #include "parser/Node.hpp"
 #include "representation/Type.hpp"
+#include <memory>
 #include <string>
 
 namespace arrow {

--- a/src/expressions/LiteralIntExpression.cpp
+++ b/src/expressions/LiteralIntExpression.cpp
@@ -2,6 +2,7 @@
 
 #include "LiteralIntExpression.hpp"
 #include "evaluator/ExpressionEvaluator.hpp"
+#include "utility/from_string.hpp"
 #include <utility>
 
 namespace arrow {
@@ -21,7 +22,7 @@ namespace arrow {
 
             Type evaluate(Environment &) const override
             {
-                return {TypeDescriptor::Int, {std::stoll(m_tok.raw)}};
+                return {TypeDescriptor::Int, {from_string<int64_t>(m_tok.raw)}};
             }
           private:
             Token m_tok;

--- a/src/expressions/LiteralRealExpression.cpp
+++ b/src/expressions/LiteralRealExpression.cpp
@@ -2,6 +2,7 @@
 
 #include "LiteralRealExpression.hpp"
 #include "evaluator/ExpressionEvaluator.hpp"
+#include "utility/from_string.hpp"
 #include <utility>
 
 namespace arrow {
@@ -21,7 +22,7 @@ namespace arrow {
 
             Type evaluate(Environment &) const override
             {
-                return {TypeDescriptor::Real, {std::stold(m_tok.raw)}};
+                return {TypeDescriptor::Real, {from_string<real>(m_tok.raw)}};
             }
           private:
             Token m_tok;

--- a/src/lexer/Lexeme.cpp
+++ b/src/lexer/Lexeme.cpp
@@ -1,6 +1,7 @@
 /// (c) Ben Jones 2019 - present
 
 #include "Lexeme.hpp"
+#include <algorithm>
 #include <map>
 #include <string>
 #include <vector>

--- a/src/lexer/Lexer.cpp
+++ b/src/lexer/Lexer.cpp
@@ -1,6 +1,7 @@
 /// (c) Ben Jones 2019 - present
 
 #include "Lexer.hpp"
+#include <algorithm>
 #include <iterator>
 #include <cctype>
 #include <cstdio>

--- a/src/receivers/Receiver.hpp
+++ b/src/receivers/Receiver.hpp
@@ -4,6 +4,7 @@
 
 #include "parser/Node.hpp"
 #include "representation/Type.hpp"
+#include <memory>
 #include <string>
 
 namespace arrow {

--- a/src/representation/Environment.cpp
+++ b/src/representation/Environment.cpp
@@ -2,6 +2,7 @@
 
 #include "Environment.hpp"
 #include "parser/LanguageException.hpp"
+#include <algorithm>
 
 namespace arrow {
 
@@ -326,6 +327,6 @@ namespace arrow {
 
     Type Environment::getProgramArgument(int64_t const index) const
     {
-        return m_programArguments[index];
+        return m_programArguments.at(index);
     }
 }

--- a/src/statements/StringToIntStatement.cpp
+++ b/src/statements/StringToIntStatement.cpp
@@ -4,6 +4,7 @@
 //#include "expressions/evaluator/ExpressionEvaluator.hpp"
 //#include "evaluator/StatementEvaluator.hpp"
 //#include "parser/LanguageException.hpp"
+//#include "utility/from_string.hpp"
 //#include <utility>
 
 namespace arrow {
@@ -37,7 +38,7 @@ namespace arrow {
                 if(type.m_descriptor != TypeDescriptor::String) {
                     throw LanguageException("Not a string", m_statement.getLineNumber());
                 }
-                auto converted = std::stold(std::get<std::string>(type.m_variantType));
+                auto converted = from_string<real>(std::get<std::string>(type.m_variantType));
                 auto identifier = m_statement.getIdentifier();
                 environment.add(identifier.raw, {TypeDescriptor::Int, converted});
                 return StatementResult::Continue;

--- a/src/utility/from_string.hpp
+++ b/src/utility/from_string.hpp
@@ -1,0 +1,12 @@
+#include <sstream>
+#include <string>
+
+namespace arrow {
+    template <typename T>
+    T from_string(std::string const & str)
+    {
+        T result;
+        std::istringstream(str) >> result;
+        return result;
+    }
+}


### PR DESCRIPTION
Hi Ben!

This pull request:
* Fixes issue 16.
* Makes arrow compile on Linux
* Makes it easier to switch between `double` and `long double` by removing usage of `std::sto*`.